### PR TITLE
Moved ECR stuff to other role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,33 @@
-# Wimpy Build
-Ansible playbook to build your application using Docker Compose, so you can define which build tool to use.
-It will then create a docker image with your application, and finally push that image to a Docker Registry.
+# Wimpy Build [![Build Status](https://travis-ci.org/wimpy/wimpy.build.svg?branch=master)](https://travis-ci.org/wimpy/wimpy.build)
+Ansible role to build your application using Docker Compose, so you can define which build tool to use.
+It will then create a Docker image with your application, and finally push that image to a Docker Registry.
 
-## Required Parameters
-The required parameters are
+## Parameters
+The parameters are
 
   - `wimpy_project_name`: The name to identify your project.
   - `wimpy_release_version`: Used for tagging your docker image.
-
-## Optional Parameters
-The optional parameters are
-
-  - `wimpy_docker_registry`: Defaults to Docker Hub. It must have trailing slash.
-  - `wimpy_docker_image_name`: Defaults to your project's name. If using private Docker Registry, this parameter must contain the registry in the name.
+  - `wimpy_docker_image_name`: (Optional: Defaults to `wimpy_project_name`). If using a Docker Registry other than DockerHub, this parameter must contain the registry host in the name.
+  - `wimpy_docker_skip_login:`: (Optional: Defaults to `False`). If using a Docker Registry that doesnt't require you to login.
 
 ### Login to Docker Registry
-This role handles the login with your Docker Registry.
+When publishing to a Docker Registry that needs you to login (like DockerHub), pass the following parameters
 
-When publishing to other Docker Registry that needs you to login (like DockerHub), pass the following parameters
+  - `wimpy_docker_registry`: **It must have trailing slash**. Empty by default, which means DockerHub.
+  - `wimpy_docker_registry_username`: Credentials for the Docker Registry.
+  - `wimpy_docker_registry_email`: Credentials for the Docker Registry.
+  - `wimpy_docker_registry_password`: Credentials for the Docker Registry.
 
-  - `wimpy_docker_registry_username`
-  - `wimpy_docker_registry_email`
-  - `wimpy_docker_registry_password`
+## Usage
 
-If you pass the `wimpy_docker_registry` parameter containing an AWS ECR address, it will login with ECR, given that the computer executing this role has the right permissions.
+```yaml
+- hosts: localhost
+  connection: local
+  vars:
+    wimpy_project_name: "my-project"
+    wimpy_release_version: "9da8s9fud8"
+  roles:
+    - wimpy.build
 
+```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ When publishing to a Docker Registry that needs you to login (like DockerHub), p
   - `wimpy_docker_registry_email`: Credentials for the Docker Registry.
   - `wimpy_docker_registry_password`: Credentials for the Docker Registry.
 
+### AWS ECR
+If you are using AWS ECR to store your Docker images, we recommend you to use [wimpy.ecr](https://github.com/wimpy/wimpy.ecr) before `wimpy.build` in your playbooks.
+
 ## Usage
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
 wimpy_docker_image_name: "{{ wimpy_project_name if wimpy_docker_registry is not defined else wimpy_docker_registry ~ wimpy_project_name }}"
-wimpy_ecr_pattern: "^(.*).dkr.ecr.(.*).amazonaws.com/$"
 wimpy_docker_build_args: {}
 wimpy_docker_compose_build: "{{ lookup('env','PWD') }}/docker-compose-build.yml"
+wimpy_docker_skip_login: False

--- a/tasks/build_docker_image.yml
+++ b/tasks/build_docker_image.yml
@@ -1,19 +1,14 @@
 ---
 
-- name: "Get ECR Token"
-  shell: "aws ecr get-authorization-token --region {{ wimpy_aws_region }} --output text --query \"authorizationData[].authorizationToken\""
-  when:
-   - wimpy_aws_region is defined
-   - wimpy_aws_account_id is defined
-  register: wimpy_aws_ecr_password
-
 - name: "Log into private registry"
   docker_login:
     registry: "{{ wimpy_docker_registry | default(omit) }}"
     email: "{{ wimpy_docker_registry_email | default(none) }}"
-    username: "{{ wimpy_docker_registry_username | default('AWS') }}"
-    password: "{{ wimpy_docker_registry_password | default((wimpy_aws_ecr_password.stdout | b64decode).split(':')[1] if wimpy_aws_ecr_password.changed else '') }}"
+    username: "{{ wimpy_docker_registry_username }}"
+    password: "{{ wimpy_docker_registry_password }}"
     reauthorize: yes
+  when:
+    - not wimpy_docker_skip_login
 
 - name: "Build docker image and push it to registry"
   docker_image:

--- a/tasks/check_parameters.yml
+++ b/tasks/check_parameters.yml
@@ -6,11 +6,3 @@
   with_items:
     - wimpy_project_name
     - wimpy_release_version
-
-- name: "Extract AWS region and account id from registry"
-  set_fact:
-    wimpy_aws_account_id: "{{ wimpy_docker_registry | regex_replace(wimpy_ecr_pattern, '\\1' ) }}"
-    wimpy_aws_region: "{{ wimpy_docker_registry | regex_replace(wimpy_ecr_pattern, '\\2' ) }}"
-  when:
-    - wimpy_docker_registry is defined
-    - wimpy_docker_registry | match(wimpy_ecr_pattern)


### PR DESCRIPTION
Everything related to ECR has been moved to https://github.com/wimpy/wimpy.ecr. That way, this `wimpy.build` role always work the same, independently of using ECR or not.