### PR TITLE
Optional new behaviours

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The parameters are
   - `wimpy_docker_image_name`: (Optional: Defaults to `wimpy_application_name`). If using a Docker Registry other than DockerHub, this parameter must contain the registry host in the name.
   - `wimpy_docker_skip_login:`: (Optional: Defaults to `False`). If using a Docker Registry that doesnt't require you to login.
   - `wimpy_docker_image_force`: (Optional: Defaults to `no`). Creates a new docker image even if one with the same name and tag already exists in the repository. Useful to override SNAPSHOT builds.
-  - `wimpy_docker_image_tag_latest`: (Optional: Defaults to `True`). Tag the new built image also as latest. If set to False will be only tagged with the version. Useful if releasing a patch for non mainstream branch like older versions or building non stable code.
+  - `wimpy_docker_image_skip_latest_tag`: (Optional: Defaults to `False`). If set to True it will not tag the built image as latest. Useful if releasing a patch for non mainstream branch like older versions or building non stable code.
 
 ### Login to Docker Registry
 When publishing to a Docker Registry that needs you to login (like DockerHub), pass the following parameters

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ The parameters are
   - `wimpy_docker_skip_login:`: (Optional: Defaults to `False`). If using a Docker Registry that doesnt't require you to login.
   - `wimpy_docker_image_force`: (Optional: Defaults to `no`). Creates a new docker image even if one with the same name and tag already exists in the repository. Useful to override SNAPSHOT builds.
   - `wimpy_docker_image_tag_latest`: (Optional: Defaults to `True`). Tag the new built image also as latest. If set to False will be only tagged with the version. Useful if releasing a patch for non mainstream branch like older versions or building non stable code.
-  - `wimpy_docker_image_delete_after_build`: (Optional: Defaults to `False`). Deletes the new built image from local docker repository (not from remote)
 
 ### Login to Docker Registry
 When publishing to a Docker Registry that needs you to login (like DockerHub), pass the following parameters

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The parameters are
   - `wimpy_release_version`: Used for tagging your docker image.
   - `wimpy_docker_image_name`: (Optional: Defaults to `wimpy_application_name`). If using a Docker Registry other than DockerHub, this parameter must contain the registry host in the name.
   - `wimpy_docker_skip_login:`: (Optional: Defaults to `False`). If using a Docker Registry that doesnt't require you to login.
+  - `wimpy_docker_image_force`: (Optional: Defaults to `no`). Creates a new docker image even if one with the same name and tag already exists in the repository. Useful to override SNAPSHOT builds.
+  - `wimpy_docker_image_tag_latest`: (Optional: Defaults to `True`). Tag the new built image also as latest. If set to False will be only tagged with the version. Useful if releasing a patch for non mainstream branch like older versions or building non stable code.
+  - `wimpy_docker_image_delete_after_build`: (Optional: Defaults to `False`). Deletes the new built image from local docker repository (not from remote)
 
 ### Login to Docker Registry
 When publishing to a Docker Registry that needs you to login (like DockerHub), pass the following parameters

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,6 @@ wimpy_docker_image_name: "{{ wimpy_application_name if wimpy_docker_registry is 
 wimpy_docker_build_args: {}
 wimpy_docker_compose_build: "{{ lookup('env','PWD') }}/docker-compose-build.yml"
 wimpy_docker_skip_login: False
+wimpy_docker_image_tag_latest: True
+wimpy_docker_image_force: no
 wimpy_aws_region: "eu-west-1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,5 +7,4 @@ wimpy_docker_compose_build: "{{ lookup('env','PWD') }}/docker-compose-build.yml"
 wimpy_docker_skip_login: False
 wimpy_docker_image_tag_latest: True
 wimpy_docker_image_force: no
-wimpy_docker_image_delete_after_build: False
 wimpy_aws_region: "eu-west-1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,4 +7,5 @@ wimpy_docker_compose_build: "{{ lookup('env','PWD') }}/docker-compose-build.yml"
 wimpy_docker_skip_login: False
 wimpy_docker_image_tag_latest: True
 wimpy_docker_image_force: no
+wimpy_docker_image_delete_after_build: False
 wimpy_aws_region: "eu-west-1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,6 @@ wimpy_docker_image_name: "{{ wimpy_application_name if wimpy_docker_registry is 
 wimpy_docker_build_args: {}
 wimpy_docker_compose_build: "{{ lookup('env','PWD') }}/docker-compose-build.yml"
 wimpy_docker_skip_login: False
-wimpy_docker_image_tag_latest: True
+wimpy_docker_image_skip_latest_tag: False
 wimpy_docker_image_force: no
 wimpy_aws_region: "eu-west-1"

--- a/tasks/build_docker_image.yml
+++ b/tasks/build_docker_image.yml
@@ -28,3 +28,19 @@
   when:
     - wimpy_docker_image_tag_latest
 
+- name: "Delete local image built"
+  docker_image:
+    name: "{{ wimpy_docker_image_name }}:{{ wimpy_release_version | string }}"
+    state: absent
+    push: no
+  when:
+    - wimpy_docker_image_delete_after_build
+
+- name: "Delete local image built (latest)"
+  docker_image:
+    name: "{{ wimpy_docker_image_name }}:latest"
+    state: absent
+    push: no
+  when:
+    - wimpy_docker_image_delete_after_build
+    - wimpy_docker_image_tag_latest

--- a/tasks/build_docker_image.yml
+++ b/tasks/build_docker_image.yml
@@ -26,4 +26,4 @@
     force: "{{ wimpy_docker_image_force }}"
     buildargs: "{{ wimpy_docker_build_args }}"
   when:
-    - wimpy_docker_image_tag_latest
+    - not wimpy_docker_image_skip_latest_tag

--- a/tasks/build_docker_image.yml
+++ b/tasks/build_docker_image.yml
@@ -15,6 +15,7 @@
     path: "{{ lookup('env','PWD') }}"
     name: "{{ wimpy_docker_image_name }}:{{ wimpy_release_version | string }}"
     push: yes
+    force: "{{ wimpy_docker_image_force }}"
     buildargs: "{{ wimpy_docker_build_args }}"
 
 - name: "Build and push latest tag"
@@ -22,4 +23,8 @@
     path: "{{ lookup('env','PWD') }}"
     name: "{{ wimpy_docker_image_name }}:latest"
     push: yes
+    force: "{{ wimpy_docker_image_force }}"
     buildargs: "{{ wimpy_docker_build_args }}"
+  when:
+    - wimpy_docker_image_tag_latest
+

--- a/tasks/build_docker_image.yml
+++ b/tasks/build_docker_image.yml
@@ -27,20 +27,3 @@
     buildargs: "{{ wimpy_docker_build_args }}"
   when:
     - wimpy_docker_image_tag_latest
-
-- name: "Delete local image built"
-  docker_image:
-    name: "{{ wimpy_docker_image_name }}:{{ wimpy_release_version | string }}"
-    state: absent
-    push: no
-  when:
-    - wimpy_docker_image_delete_after_build
-
-- name: "Delete local image built (latest)"
-  docker_image:
-    name: "{{ wimpy_docker_image_name }}:latest"
-    state: absent
-    push: no
-  when:
-    - wimpy_docker_image_delete_after_build
-    - wimpy_docker_image_tag_latest


### PR DESCRIPTION
Hello,

Under my release pipeline I found some features that would be nice to be included in the project:

## 1. Optional latest tagging
Sometimes, you may need to patch an older version of a project, maybe a security patch or some critical errors may appear in older versions and you need to update them. For these builds, even you want to provide the docker image with the new version you don't want it to become latest. With the new `wimpy_docker_image_tag_latest` flag you can skip tagging latest.

## 2. Delete local images after push
If you run the builds in your CI/CD server (jenkins for example) the local docker registry will fill up with all the built images. In our scenario, the CI/CD system doesn't need the images after they have been pushed to the remote registry, so a new task using the flag `wimpy_docker_image_delete_after_build` will delete the just built images from just the local docker registry (not from the remote)

## 3. Force image rebuild
If you use the "SNAPSHOT" approach release cycle, so a new version under development is always tagged as "{NEW-EXPECTED-VERSION}-SNAPSHOT" (example: 1.2.0-SNAPSHOT) until the final release is ready and running the build always in the same server (and not deleting the local images with the new functionality) the docker_image module will not rebuild the image, just pushes the existing image again to the remote. docker_image module allows the `force` flag to rebuild it in any case. This PR adds a new `wimpy_docker_image_force` option to allow this.


All these new features included in this PR have a default value to just work as it did before. So no breaking changes are introduced.
